### PR TITLE
Journalist can choose category for article

### DIFF
--- a/app/controllers/cms/articles_controller.rb
+++ b/app/controllers/cms/articles_controller.rb
@@ -20,7 +20,7 @@ class Cms::ArticlesController < ApplicationController
   private
 
   def article_params
-    params.require(:article).permit(:title, :lede, :body, :author)
+    params.require(:article).permit(:title, :lede, :body, :author, :category_id)
   end
 
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,4 +2,5 @@ class Article < ApplicationRecord
 
   validates_presence_of  :title, :lede, :body, :author
 
+  belongs_to :category
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,4 @@
 class Article < ApplicationRecord
-
   validates_presence_of  :title, :lede, :body, :author
-
   belongs_to :category
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+    validates_presence_of :name
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,6 @@
 class Category < ApplicationRecord
     validates_presence_of :name
+
+    has_many :articles
+    
 end

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,6 +1,7 @@
 %h2 Articles
 - @articles.each do |article|
   %h3= link_to "#{article.title}", article
+  %p= article.category.name
   %p= image_tag("article.jpg")  
   %p= article.lede
   %p= article.author

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -1,5 +1,6 @@
 
 %h1= @article.title
+%p= @article.category.name
 %p= image_tag("article.jpg")
 %p= @article.body
 %p= @article.author

--- a/app/views/cms/articles/index.html.haml
+++ b/app/views/cms/articles/index.html.haml
@@ -1,6 +1,4 @@
--if user_signed_in?
-  %p="Hello, #{current_user.first_name}!"
-  %p=link_to "Log out", destroy_user_session_path, method: :delete
+
 
 %h1 List of articles
 %table

--- a/app/views/cms/articles/new.html.haml
+++ b/app/views/cms/articles/new.html.haml
@@ -19,8 +19,9 @@
   %p
     = form.label :author
     = form.text_field :author
-  %p
-    = form.collection_select(:category_id, Category.all, :id, :name) 
+  %br
+    = form.label :category
+    .Category= form.collection_select :category_id, Category.all, :id, :name 
 
   %p
     = form.submit

--- a/app/views/cms/articles/new.html.haml
+++ b/app/views/cms/articles/new.html.haml
@@ -20,4 +20,7 @@
     = form.label :author
     = form.text_field :author
   %p
+    = form.collection_select(:category_id, Category.all, :id, :name) 
+
+  %p
     = form.submit

--- a/db/migrate/20190115122008_create_categories.rb
+++ b/db/migrate/20190115122008_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190115123959_add_category_to_articles.rb
+++ b/db/migrate/20190115123959_add_category_to_articles.rb
@@ -1,0 +1,5 @@
+class AddCategoryToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :articles, :category, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_15_090605) do
+ActiveRecord::Schema.define(version: 2019_01_15_122008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,12 @@ ActiveRecord::Schema.define(version: 2019_01_15_090605) do
     t.text "lede"
     t.text "body"
     t.string "author"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_15_122008) do
+ActiveRecord::Schema.define(version: 2019_01_15_123959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2019_01_15_122008) do
     t.string "author"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_articles_on_category_id"
   end
 
   create_table "categories", force: :cascade do |t|
@@ -45,4 +47,5 @@ ActiveRecord::Schema.define(version: 2019_01_15_122008) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "articles", "categories"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 5.times do
-    Article.create(title: "Title", lede: "Lorem ipsum dolor sit amet.", body:"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", author:"author")
+    Article.create(title: "Title", lede: "Lorem ipsum dolor sit amet.", body:"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", author:"author", category_id: 1)
 end
 
 User.create(email: "member@mail.com", password: "membermember", first_name: "Member", last_name: "Member", role: 0)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,8 +5,8 @@ end
 User.create(email: "member@mail.com", password: "membermember", first_name: "Member", last_name: "Member", role: 0)
 User.create(email: "journalist@mail.com", password: "journalist", first_name: "Journo", last_name: "Journo", role: 1)
 
-Category.create(name: "Sports")
-Category.create(name: "Politics")
-Category.create(name: "Health")
-Category.create(name: "Finance")
-Category.create(name: "Entertainment")
+categories = ["Sports", "Politics", "Health", "Finance", "Entertainment"]
+
+categories.each do |category| 
+    Category.create(name: category)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,3 +4,9 @@ end
 
 User.create(email: "member@mail.com", password: "membermember", first_name: "Member", last_name: "Member", role: 0)
 User.create(email: "journalist@mail.com", password: "journalist", first_name: "Journo", last_name: "Journo", role: 1)
+
+Category.create(name: "Sports")
+Category.create(name: "Politics")
+Category.create(name: "Health")
+Category.create(name: "Finance")
+Category.create(name: "Entertainment")

--- a/features/journalist_can_create_article.feature
+++ b/features/journalist_can_create_article.feature
@@ -8,6 +8,11 @@ Feature: Create articles
     | first_name  | last_name    | email          | password | role      |
     | Hanna       | Nyman        | hanna@tuna.se  | password | journalist|
     | William     | Schneiderman | will@gmail.com | password | member    |
+    And the following categories exists
+    |name    |
+    |Sports  |
+    |Politics|
+    |Health  |
     
   Scenario: Journalist navigates to create article page
     When I am logged in as "hanna@tuna.se"
@@ -35,4 +40,4 @@ Feature: Create articles
     When I am logged in as "hanna@tuna.se"
     And I click "New article"
     And I click "Create Article"
-    Then I should see "5 errors prohibited this article from being saved"
+    Then I should see "4 errors prohibited this article from being saved"

--- a/features/journalist_can_create_article.feature
+++ b/features/journalist_can_create_article.feature
@@ -25,6 +25,7 @@ Feature: Create articles
     And I fill in "Lede" with "This is the lede paragraph"
     And I fill in "Body" with "Excited about learning a new framework"
     And I fill in "Author" with "Shahin"
+    And I select "Politics" from "Category"
     And I click "Create Article" 
     Then I should be on journalist index page
     And I should see "Learning Rails 5"
@@ -34,4 +35,4 @@ Feature: Create articles
     When I am logged in as "hanna@tuna.se"
     And I click "New article"
     And I click "Create Article"
-    Then I should see "4 errors prohibited this article from being saved"
+    Then I should see "5 errors prohibited this article from being saved"

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -17,3 +17,7 @@ end
 Then("I should be on journalist index page") do
   expect(current_path).to eq cms_articles_path
 end
+
+Then("I am on Sign up page") do
+  expect(current_path).to eq new_user_registration_path
+end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -28,5 +28,5 @@ When("I click {string}") do |element|
 end
 
 When("I select {string} from {string}") do |option, selection|
-  select option, from: selection
+  select option, from: `product.#{selection}`
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -27,6 +27,6 @@ When("I click {string}") do |element|
   click_on element
 end
 
-Then("I am on Sign up page") do
-  expect(current_path).to eq new_user_registration_path
+When("I select {string} from {string}") do |option, selection|
+  select option, from: selection
 end

--- a/features/step_definitions/new_objects_steps.rb
+++ b/features/step_definitions/new_objects_steps.rb
@@ -3,3 +3,9 @@ Given("the following articles exists") do |table|
     article = create(:article, article)
   end
 end
+
+Given("the following categories exists") do |table|
+  table.hashes.each do |category|
+    category = create(:category, category)
+  end
+end

--- a/features/user_can_read_an_article.feature
+++ b/features/user_can_read_an_article.feature
@@ -5,12 +5,12 @@ Feature: User can see the details of a specific article
   I would like to be able to click on an article and have it displayed
 
    Background: 
-   And the following categories exists
+   Given the following categories exists
     |name    | id |
     |Sports  | 1  |
     |Politics| 2  |
     |Health  | 3  |
-    Given the following articles exists
+    And the following articles exists
       | title                | body                          | author  | created_at  | category_id |
       | A breaking news item | hello this is about me        | William | 2012-12-12  | 1           |
       | Learn Rails 5        | hello this is about that guy  | Camron  | 2013-11-11  | 3           |

--- a/features/user_can_read_an_article.feature
+++ b/features/user_can_read_an_article.feature
@@ -4,11 +4,17 @@ Feature: User can see the details of a specific article
   In order to read an article
   I would like to be able to click on an article and have it displayed
 
-   Background:  
+   Background: 
+   And the following categories exists
+    |name    | id |
+    |Sports  | 1  |
+    |Politics| 2  |
+    |Health  | 3  |
     Given the following articles exists
-      | title                | body                          | author  | created_at  | 
-      | A breaking news item | hello this is about me        | William | 2012-12-12  | 
-      | Learn Rails 5        | hello this is about that guy  | Camron  | 2013-11-11  |
+      | title                | body                          | author  | created_at  | category_id |
+      | A breaking news item | hello this is about me        | William | 2012-12-12  | 1           |
+      | Learn Rails 5        | hello this is about that guy  | Camron  | 2013-11-11  | 3           |
+    
 
     Scenario: User can see the details of a specific article 
       When I visit the site
@@ -16,8 +22,10 @@ Feature: User can see the details of a specific article
       Then I should see 'William'
       And I should see 'hello this is about me'
       And I should see '2012-12-12'
+      And I should see 'Sports'
       When I click 'back'
       And I click 'Learn Rails 5'
       Then I should see 'hello this is about that guy' 
       And I should see 'Camron'
       And I should see '2013-11-11' 
+      And I should see 'Health' 

--- a/features/view_articles.feature
+++ b/features/view_articles.feature
@@ -5,10 +5,16 @@ In order to choose an article to read
 I would like to be able to see the articles listed on a page
 
   Scenario: View list of articles on the index page
-    Given the following articles exists
-      | title                | lede                         | author  | 
-      | A breaking news item | hello this is about me       | William | 
-      | Learn Rails 5        | hello this is about that guy | Camron  | 
+  Given the following categories exists
+    |name    | id |
+    |Sports  | 1  |
+    |Politics| 2  |
+    |Health  | 3  |
+
+  And the following articles exists
+    | title                | lede                         | author  | category_id |
+    | A breaking news item | hello this is about me       | William | 1           |
+    | Learn Rails 5        | hello this is about that guy | Camron  | 2           |
     When I visit the site
     Then I should see "A breaking news item"
     And I should see "Learn Rails 5"
@@ -16,6 +22,8 @@ I would like to be able to see the articles listed on a page
     And I should see "Camron"
     And I should see "hello this is about me"
     And I should see "hello this is about that guy"
+    And I should see "Sports"
+    And I should see "Politics"
 
 
     

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     lede { "MyText" }
     body { "MyText" }
     author { "MyString" }
+    association :category, factory: :category
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    name { "MyString" }
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  describe 'DB table' do
+    it { is_expected.to have_db_column :name }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :name }
+  end
+
+  describe FactoryBot do 
+    it 'should be valid' do
+      expect(create(:category)).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
# PT Link

[Journalist can categorize Articles depending on topic](https://www.pivotaltracker.com/story/show/163086998)

# User Story

```
As a journalist
In order to distinguish my articles to a relevant topic
I would like to be able to associate them with different categories
```

# Screenshots

<img width="346" alt="screenshot 2019-01-15 at 16 39 32" src="https://user-images.githubusercontent.com/43759826/51191218-39a16780-18e4-11e9-894f-3c859d32f9cb.png">


<img width="603" alt="screenshot 2019-01-15 at 16 39 48" src="https://user-images.githubusercontent.com/43759826/51191239-3dcd8500-18e4-11e9-814c-b88685465812.png">


# Description of PR
journalist is now able to add a category to article 
