### PR TITLE
[WIP] Journalist can create and edit articles using markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'launchy'
 gem 'rails-i18n'
 gem 'stripe-rails'
 gem 'aws-sdk-s3'
+gem 'redcarpet'
 
 group :development, :test do
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redcarpet (3.4.0)
     regexp_parser (1.3.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -372,6 +373,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.2)
   rails-i18n
+  redcarpet
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+    def markdown(text)
+        renderer = Redcarpet::Render::HTML.new(no_links: true, hard_wrap: true)
+        markdown = Redcarpet::Markdown.new(renderer, extensions = {})
+        markdown.render(text).html_safe
+    end
 end

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -1,7 +1,7 @@
 %h1= @article.title
 %p= @article.category.name
 %p= image_tag @article.image if @article.image.attached?  
-%p= @article.body
+%p= markdown(@article.body)
 %p 
   =t('author') 
   = @article.user.first_name


### PR DESCRIPTION
# PT Link

[Journalist can create and edit articles using markdown](https://www.pivotaltracker.com/story/show/163336995)

# User Story

```
As a user
In order to create more structured articles
I would like to be able to use markdown on the body of the article
```

# Screenshots
![jan-18-2019 21-51-20](https://user-images.githubusercontent.com/43814981/51412253-3f5cae80-1b6b-11e9-9657-c0338618d2a9.gif)

# Description of PR

- Adds redcarpet gem
- Configures markdown
